### PR TITLE
Fix clippy warnings leaking into code using derive(Target)

### DIFF
--- a/yew-nested-router-macros/src/lib.rs
+++ b/yew-nested-router-macros/src/lib.rs
@@ -493,8 +493,8 @@ fn predicates(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
             Fields::Named(_) => {
                 quote_spanned! { v.span() =>
                     #[allow(unused)]
-                    pub fn #fn_name(self) -> bool {
-                        matches!(self, Self::#name{..})
+                    pub fn #fn_name(&self) -> bool {
+                        matches!(*self, Self::#name{..})
                     }
                 }
             }

--- a/yew-nested-router-macros/src/lib.rs
+++ b/yew-nested-router-macros/src/lib.rs
@@ -439,7 +439,7 @@ fn mappers(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
                         F: Fn(#types) -> R,
                         R: std::default::Default
                     {
-                        move |s| s.#map_name().map(|v|f(v)).unwrap_or_default()
+                        move |s| s.#map_name().map(&f).unwrap_or_default()
                     }
                 }
             },
@@ -458,7 +458,7 @@ fn mappers(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
                     F: Fn(#types) -> R,
                     R: std::default::Default
                 {
-                    move |s| s.#map_name().map(|v|f(v)).unwrap_or_default()
+                    move |s| s.#map_name().map(&f).unwrap_or_default()
                 }
             },
         }

--- a/yew-nested-router-macros/src/lib.rs
+++ b/yew-nested-router-macros/src/lib.rs
@@ -493,8 +493,9 @@ fn predicates(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
             Fields::Named(_) => {
                 quote_spanned! { v.span() =>
                     #[allow(unused)]
-                    pub fn #fn_name(&self) -> bool {
-                        matches!(*self, Self::#name{..})
+                    #[allow(clippy::wrong_self_convention)]
+                    pub fn #fn_name(self) -> bool {
+                        matches!(self, Self::#name{..})
                     }
                 }
             }


### PR DESCRIPTION
Current versions of clippy (e.g. 0.1.71) show warnings when using `derive(Target)` because of the generated code.

You can see these when running `cargo clippy --tests` in this repo.

This PR takes care of the two issues which were popping up.