### PR TITLE
Use &self in predicates

### DIFF
--- a/yew-nested-router-macros/src/lib.rs
+++ b/yew-nested-router-macros/src/lib.rs
@@ -477,7 +477,7 @@ fn predicates(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
         match &v.fields {
             Fields::Unit => quote_spanned! { v.span() =>
                 #[allow(unused)]
-                pub fn #fn_name(self) -> bool {
+                pub fn #fn_name(&self) -> bool {
                     matches!(self, Self::#name)
                 }
             },
@@ -485,8 +485,8 @@ fn predicates(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
                 let captures = fields.unnamed.iter().map(|_| quote! {_});
                 quote_spanned! { v.span() =>
                     #[allow(unused)]
-                    pub fn #fn_name(self) -> bool {
-                        matches!(self, Self::#name( #(#captures),* ))
+                    pub fn #fn_name(&self) -> bool {
+                        matches!(self, Self::#name( .. ))
                     }
                 }
             }
@@ -494,7 +494,7 @@ fn predicates(data: &DataEnum) -> impl Iterator<Item = TokenStream> + '_ {
                 quote_spanned! { v.span() =>
                     #[allow(unused)]
                     #[allow(clippy::wrong_self_convention)]
-                    pub fn #fn_name(self) -> bool {
+                    pub fn #fn_name(&self) -> bool {
                         matches!(self, Self::#name{..})
                     }
                 }


### PR DESCRIPTION
Detected by a clippy warning and avoids needing to Clone paths for types that are not Copy (such as including String or IString).