### PR TITLE
feat: Render "href" attribute when using "a" as element

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         toolchain:
           - stable
-          # minimum version for Yew
-          - "1.60"
+          # minimum version for Tokio
+          - "1.63"
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yew-nested-router"
 description = "A router for Yew which supports nesting"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Jens Reimann <jreimann@redhat.com>"]
 license = "Apache-2.0"
@@ -12,8 +12,9 @@ readme = "README.md"
 rust-version = "1.60"
 
 [dependencies]
-gloo-history = "0.1.2"
-gloo-utils = "0.1.6"
+gloo-history = "0.1"
+gloo-utils = "0.2"
+gloo-events = "0.1"
 log = "0.4"
 urlencoding = "2"
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ urlencoding = "2"
 wasm-bindgen = "0.2"
 yew = "0.20"
 
-yew-nested-router-macros = { version = "0.2.2", path = "yew-nested-router-macros" }
+yew-nested-router-macros = { version = "0.3.0", path = "yew-nested-router-macros" }
 
 web-sys = { version = "0.3", features = [
     "HtmlBaseElement",

--- a/yew-nested-router-macros/Cargo.toml
+++ b/yew-nested-router-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yew-nested-router-macros"
 description = "Macro support for yew-nested-router"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Jens Reimann <jreimann@redhat.com>"]
 license = "Apache-2.0"
@@ -15,7 +15,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-# need to stick to syn1 until darling catched up
 syn = { version = "2", features = ["full"] }
 darling = "0.20"
 convert_case = "0.6.0"


### PR DESCRIPTION
Rendering the "href" attribute in addition, which allows the user to middle-click a link, opening it in another tab. For this to work, it is also necessary to prevent the default action of the link, which requires the use of gloo_events, as yew doesn't allow this.