### PR TITLE
Document nesting with value

### DIFF
--- a/examples/yew-nested-router-example/src/app.rs
+++ b/examples/yew-nested-router-example/src/app.rs
@@ -38,6 +38,28 @@ fn render(page: Page) -> Html {
                 <Link<Page> target={Page::B(B::Two(View::Details))}>{ "Jump to Page::B(B::Two(View::Details))" }</Link<Page>>
             </nav>
         </Section>),
+        Page::D { id, target: _target } => html!(
+            <Scope<Page, D> mapper={move |_| Page::mapper_d(id)}>
+                <Section>
+                    <h3>{ "D" }</h3>
+                    <nav>
+                        <ul>
+                            <li><Link<Page> target={Page::Index}>{ "Home" }</Link<Page>></li>
+                            <li><Link<D> active="active" predicate={D::is_first} target={D::First}>{ "First" }</Link<D>></li>
+                            <li><Link<D> active="active" predicate={D::is_second} target={D::Second}>{ "Second" }</Link<D>></li>
+                        </ul>
+                    </nav>
+                </Section>
+                <Switch<D> render={move |d| render_d(d, id)} />
+            </Scope<Page, D>>
+        ),
+    }
+}
+
+fn render_d(d: D, id: u32) -> Html {
+    match d {
+        D::First => html!(<Section><h2>{format!("First; id={id}")}</h2></Section>),
+        D::Second => html!(<Section><h2>{format!("Second; id={id}")}</h2></Section>),
     }
 }
 
@@ -149,6 +171,7 @@ pub fn app() -> Html {
                                     <li><Link<Page> active="active" target={Page::A}>{ "A" }</Link<Page>></li>
                                     <li><Link<Page> active="active" predicate={Page::is_b} target={Page::B(B::One)}>{ "B" }</Link<Page>></li>
                                     <li><Link<Page> active="active" predicate={Page::is_c} target={Page::C{value: "foo".into(), target: C::Foo{value: "value".to_string()}}}>{ "C (foo)" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" predicate={Page::is_c} target={Page::D {id: 0, target: D::First}}>{ "D (id=0)" }</Link<Page>></li>
                                 </ul>
                             </nav>
                         </div>

--- a/examples/yew-nested-router-example/src/targets.rs
+++ b/examples/yew-nested-router-example/src/targets.rs
@@ -1,4 +1,4 @@
-use yew_nested_router::prelude::Target;
+use yew_nested_router::prelude::{Mapper, Target};
 
 #[derive(Clone, Debug, PartialEq, Eq, Target)]
 pub enum Page {
@@ -15,6 +15,24 @@ pub enum Page {
         #[target(nested)]
         target: C,
     },
+    /// Nested target with custom mapper that captures value
+    D {
+        id: u32,
+        #[target(nested)]
+        target: D,
+    },
+}
+
+impl Page {
+    // We will need to pass the id in from a closure when calling this
+    pub fn mapper_d(id: u32) -> Mapper<Page, D> {
+        let downwards = |page| match page {
+            Page::D { target, .. } => Some(target),
+            _ => None,
+        };
+        let upwards = move |d| Page::D { id, target: d };
+        Mapper::new(downwards, upwards)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Target)]
@@ -46,4 +64,11 @@ pub enum View {
     Overview,
     Details,
     Source,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Target)]
+pub enum D {
+    #[default]
+    First,
+    Second,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@
 //!
 //! **NOTE:** Targets having additional information do not get a mapper automatically created, as
 //! that information might not be known on the lower levels.
+//! In these cases you will have to implement the mapper yourself.
+//! An example is provided for the target `Page::D` in the `examples` folder.
 //!
 //! For a more complete example on nesting, see the full example in the `examples` folder.
 //!

--- a/src/target.rs
+++ b/src/target.rs
@@ -31,9 +31,12 @@ pub trait Target: Clone + Debug + Eq + 'static {
     fn parse_path(path: &[&str]) -> Option<Self>;
 }
 
+/// Maps a `P`arent target onto a `C`hild target and vice versa.
 #[derive(Debug, PartialEq)]
 pub struct Mapper<P, C> {
+    /// Obtain the child target from the parent
     pub downwards: Callback<P, Option<C>>,
+    /// Obtain the parent target from the child
     pub upwards: Callback<C, P>,
 }
 


### PR DESCRIPTION
The documentation currently states that the mapper function isn't generated when using values alongside nested targets. The provided example also doesn't give an example on scoping with such values.

This PR provides an additional example which has the sole purpose of showing how what a mapper could like to achieve a path such a `/d/{id}/{first/second}`.