### PR TITLE
Allow pushing the page state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 rust-version = "1.60"
 
 [dependencies]
-gloo-history = "0.2"
 gloo-utils = "0.2"
 gloo-events = "0.2"
+js-sys = "0.3"
 log = "0.4"
 urlencoding = "2"
 wasm-bindgen = "0.2"

--- a/examples/yew-nested-router-example/Cargo.toml
+++ b/examples/yew-nested-router-example/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4"
+gloo-utils = "0.2"
 yew = { version = "0.21", features = ["csr"] }
 yew-nested-router = { path = "../.." }
 

--- a/examples/yew-nested-router-example/src/app.rs
+++ b/examples/yew-nested-router-example/src/app.rs
@@ -183,6 +183,20 @@ pub fn app() -> Html {
 
             </div>
 
+            <section>
+                <h3>{"Extras"}</h3>
+                <ul>
+                    <li>
+                        <Link<Page>
+                            target={Page::B(B::Two(View::Details))}
+                            state="Hello World!"
+                        >
+                            {"Push to B -> Two -> Details with state"}
+                        </Link<Page>>
+                    </li>
+                </ul>
+            </section>
+
             <footer>
                 <Debug/>
             </footer>

--- a/examples/yew-nested-router-example/src/components/debug.rs
+++ b/examples/yew-nested-router-example/src/components/debug.rs
@@ -8,6 +8,7 @@ pub fn debug() -> Html {
 
     let route = router.and_then(|r| r.active().clone());
     let path = route.as_ref().map(|r| r.render_path());
+    let state = gloo_utils::history().state();
 
     html!(
         <dl>
@@ -15,6 +16,8 @@ pub fn debug() -> Html {
             <dd><pre><code>{ format!("{route:?}") }</code></pre></dd>
             <dt>{"Active Path"}</dt>
             <dd><pre><code>{ format!("{path:?}") }</code></pre></dd>
+            <dt>{"Active State"}</dt>
+            <dd><pre><code>{ format!("{state:?}") }</code></pre></dd>
         </dl>
-    ) 
+    )
 }

--- a/src/components/link.rs
+++ b/src/components/link.rs
@@ -1,5 +1,6 @@
 use crate::prelude::{use_router, Target};
 use gloo_events::{EventListener, EventListenerOptions};
+use std::rc::Rc;
 use web_sys::HtmlElement;
 use yew::prelude::*;
 
@@ -18,6 +19,10 @@ where
 
     /// The link target.
     pub target: T,
+
+    /// A state to push, if present
+    #[prop_or_default]
+    pub state: Option<AttrValue>,
 
     #[prop_or_default]
     pub any: bool,
@@ -90,20 +95,29 @@ where
     let node_ref = use_node_ref();
 
     use_effect_with(
-        (router, props.target.clone(), node_ref.clone()),
-        |(router, target, node_ref)| {
+        (
+            router,
+            props.target.clone(),
+            props.state.clone(),
+            node_ref.clone(),
+        ),
+        |(router, target, state, node_ref)| {
             let mut listener = None;
 
             if let Some(element) = node_ref.cast::<HtmlElement>() {
                 let router = router.clone();
                 let target = target.clone();
+                let state = state.clone();
                 listener = Some(EventListener::new_with_options(
                     &element,
                     "click",
                     EventListenerOptions::enable_prevent_default(),
                     move |e| {
                         e.prevent_default();
-                        router.push(target.clone());
+                        router.push_with(
+                            target.clone(),
+                            state.clone().map(|s| Rc::new(s.to_string())),
+                        );
                     },
                 ));
             }

--- a/src/components/link.rs
+++ b/src/components/link.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{use_router, Target};
+use crate::state::State;
 use gloo_events::{EventListener, EventListenerOptions};
-use std::rc::Rc;
 use web_sys::HtmlElement;
 use yew::prelude::*;
 
@@ -22,7 +22,7 @@ where
 
     /// A state to push, if present
     #[prop_or_default]
-    pub state: Option<AttrValue>,
+    pub state: State,
 
     #[prop_or_default]
     pub any: bool,
@@ -37,6 +37,10 @@ where
     /// Suppress rendering the "href" attribute in any case.
     #[prop_or_default]
     pub suppress_href: bool,
+
+    /// Suppress rendering the state to the "hash" of the "href".
+    #[prop_or_default]
+    pub suppress_hash: bool,
 
     /// CSS classes which are always present.
     #[prop_or_default]
@@ -88,7 +92,9 @@ where
     }
 
     let href = match props.element.as_str() {
-        "a" if !props.suppress_href => Some(router.render_target(props.target.clone())),
+        "a" if !props.suppress_href => {
+            Some(router.render_target_with(props.target.clone(), props.state.clone()))
+        }
         _ => None,
     };
 
@@ -114,10 +120,7 @@ where
                     EventListenerOptions::enable_prevent_default(),
                     move |e| {
                         e.prevent_default();
-                        router.push_with(
-                            target.clone(),
-                            state.clone().map(|s| Rc::new(s.to_string())),
-                        );
+                        router.push_with(target.clone(), state.clone());
                     },
                 ));
             }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,68 @@
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+use wasm_bindgen::JsValue;
+
+thread_local! {
+    static INSTANCE: RefCell<InnerHistory> = RefCell::new(InnerHistory {
+        listeners: vec![],
+    });
+}
+
+/// Handle to a history listener.
+///
+/// Disposes the listener when dropped.
+pub struct HistoryListener(Rc<CallbackFn>);
+
+pub struct History;
+
+impl History {
+    /// Subscribe to events of the browser history.
+    ///
+    /// This will receive events when popping items from the stack, as well as changes triggered by calling
+    /// [`History::push_state`].
+    #[must_use = "The listener will only be active for as long as the returned instance exists."]
+    pub fn listener<F: Fn() + 'static>(f: F) -> HistoryListener {
+        INSTANCE.with(|instance| instance.borrow_mut().listener(f))
+    }
+
+    /// Push a new state to the history stack.
+    ///
+    /// This will send out events and update the browser's history. Ultimately calling
+    /// [`web_sys::History::push_state_with_url`].
+    pub fn push_state(state: JsValue, url: &str) -> Result<(), JsValue> {
+        INSTANCE.with(|instance| instance.borrow_mut().push_state(state, url))
+    }
+}
+
+type CallbackFn = dyn Fn() + 'static;
+
+struct InnerHistory {
+    listeners: Vec<Weak<CallbackFn>>,
+}
+
+impl InnerHistory {
+    fn push_state(&mut self, state: JsValue, url: &str) -> Result<(), JsValue> {
+        let result = gloo_utils::history().push_state_with_url(&state, "", Some(url));
+        self.notify();
+        result
+    }
+
+    fn listener<F: Fn() + 'static>(&mut self, f: F) -> HistoryListener {
+        let callback = Rc::new(f) as Rc<CallbackFn>;
+        self.listeners.push(Rc::downgrade(&callback));
+        HistoryListener(callback)
+    }
+
+    fn notify(&mut self) {
+        let mut new = vec![];
+
+        for listener in &mut self.listeners {
+            if let Some(cb) = listener.upgrade() {
+                (*cb)();
+                new.push(listener.clone());
+            }
+        }
+
+        self.listeners = new;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! # use yew::prelude::*;
 //! # use yew_nested_router::prelude::*;
 //! # #[derive(Clone, Debug, PartialEq, Eq, Target)]
-//! # pub enum AppRoute { Index };
+//! # pub enum AppRoute { Index }
 //! # #[function_component(MyContent)] fn my_content() -> Html { html!() }
 //! #[function_component(MyApp)]
 //! pub fn my_app() -> Html {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,15 @@
 //! }
 //! ```
 //!
+//! ## Interoperability
+//!
+//! This implementation makes use of the browser's history API. While it is possible to receive the current state
+//! from the History API, and trigger "back" operations, using [`web_sys::History::push_state`] directly will not
+//! trigger an event and thus no render a different page.
+//!
+//! As `gloo_history` creates its internal type and state system, it is not interoperable with this crate. It still is
+//! possible to use [`gloo_utils::history`] though, which is just a shortcut of getting [`web_sys::History`].
+//!
 //! ## More examples
 //!
 //! See the `examples` folder.
@@ -231,6 +240,7 @@ pub mod components;
 pub mod target;
 
 mod base;
+mod history;
 mod router;
 mod scope;
 mod state;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,7 @@ pub mod target;
 mod base;
 mod router;
 mod scope;
+mod state;
 mod switch;
 
 pub use router::Router;
@@ -244,13 +245,9 @@ pub use yew_nested_router_macros::Target;
 pub mod prelude {
     pub use super::router::*;
     pub use super::scope::*;
+    pub use super::state::*;
     pub use super::switch::*;
     pub use super::target::*;
 
     pub use yew_nested_router_macros::Target;
 }
-
-/// Re-export the version of gloo_history we use
-pub use gloo_history as history;
-/// Re-export the history implementation we use
-pub use gloo_history::BrowserHistory as History;

--- a/src/router.rs
+++ b/src/router.rs
@@ -276,7 +276,7 @@ impl<T: Target> Router<T> {
             .split('/')
             .skip(1)
             // urldecode in the process
-            .map(|segment| urlencoding::decode(segment))
+            .map(urlencoding::decode)
             .collect();
 
         // get a path, or return none if we had an urldecode error
@@ -286,12 +286,7 @@ impl<T: Target> Router<T> {
         };
 
         // parse the path into a target
-        // log::debug!("Path: {path:?}");
-        let target = T::parse_path(&path);
-        // log::debug!("New target: {target:?}");
-
-        // done
-        target
+        T::parse_path(&path)
     }
 
     fn sync_context(&mut self, ctx: &Context<Self>) {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,15 +1,16 @@
 use crate::router::RouterContext;
 use crate::target::{Mapper, Target};
-use std::rc::Rc;
+use wasm_bindgen::JsValue;
 use yew::prelude::*;
 
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct NavigationTarget<T>
 where
     T: Target,
 {
     pub target: T,
-    pub state: Option<Rc<String>>,
+    pub state: JsValue,
 }
 
 impl<T> NavigationTarget<T>
@@ -44,15 +45,12 @@ where
     pub(crate) fn push(&self, target: C) {
         self.upwards.emit(NavigationTarget {
             target,
-            state: None,
+            state: JsValue::null(),
         });
     }
 
-    pub(crate) fn push_with(&self, target: C, state: impl Into<Option<Rc<String>>>) {
-        self.upwards.emit(NavigationTarget {
-            target,
-            state: state.into(),
-        })
+    pub(crate) fn push_with(&self, target: C, state: JsValue) {
+        self.upwards.emit(NavigationTarget { target, state })
     }
 
     pub(crate) fn collect(&self, target: C) -> String {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,30 @@
+use wasm_bindgen::JsValue;
+use yew::html::IntoPropValue;
+
+/// A page state value
+#[derive(PartialEq, Debug, Clone)]
+pub struct State(pub(crate) JsValue);
+
+impl State {
+    pub const fn null() -> Self {
+        State(JsValue::null())
+    }
+}
+
+impl From<JsValue> for State {
+    fn from(value: JsValue) -> Self {
+        Self(value)
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
+impl IntoPropValue<State> for &str {
+    fn into_prop_value(self) -> State {
+        State(JsValue::from_str(self))
+    }
+}


### PR DESCRIPTION
This is change re-implements the core browser interaction so that it is possible to push a page state alongside the URL update.

Before, `gloo_history` was used, which created its own type and state system in order to support handling arbitrary Rust types. However, this breaks the interoperability with the web world, which neither knows about this internal type system or can interact with it.

Therefore the change includes a custom wrapper around the browser History API, leveraging its state and using a plain `JsValue` type.