### PR TITLE
feat: expose History to the public interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ pub use router::Router;
 pub use scope::Scope;
 pub use switch::Switch;
 pub use yew_nested_router_macros::Target;
+pub use history::History;
 
 /// Common includes.
 pub mod prelude {


### PR DESCRIPTION
Necessary for fully functional https://github.com/ctron/yew-oauth2/pull/25

I don't know if it would be good for prelude as well - I feel like it's something that shouldn't be encouraged to commonly use on its own, so keeping `History` out of it makes sense to me personally. 