### PR TITLE
refactor: Resolve name collision of route target attribute

### DIFF
--- a/examples/yew-nested-router-example/src/app.rs
+++ b/examples/yew-nested-router-example/src/app.rs
@@ -20,10 +20,10 @@ fn render(page: Page) -> Html {
                     <h3>{ "B" }</h3>
                     <nav>
                         <ul>
-                            <li><Link<Page> target={Page::Index}>{ "Home" }</Link<Page>></li>
-                            <li><Link<B> active="active" target={B::One}>{ "One" }</Link<B>></li>
-                            <li><Link<B> active="active" predicate={B::is_two} target={B::Two(View::Overview)}>{ "Two" }</Link<B>></li>
-                            <li><Link<B> active="active" predicate={B::is_three} target={B::Three(View::Overview)}>{ "Three" }</Link<B>></li>
+                            <li><Link<Page> to={Page::Index}>{ "Home" }</Link<Page>></li>
+                            <li><Link<B> active="active" to={B::One}>{ "One" }</Link<B>></li>
+                            <li><Link<B> active="active" predicate={B::is_two} to={B::Two(View::Overview)}>{ "Two" }</Link<B>></li>
+                            <li><Link<B> active="active" predicate={B::is_three} to={B::Three(View::Overview)}>{ "Three" }</Link<B>></li>
                         </ul>
                     </nav>
                 </Section>
@@ -35,7 +35,7 @@ fn render(page: Page) -> Html {
                 { format!("C ({value})") }
             </h3>
             <nav>
-                <Link<Page> target={Page::B(B::Two(View::Details))}>{ "Jump to Page::B(B::Two(View::Details))" }</Link<Page>>
+                <Link<Page> to={Page::B(B::Two(View::Details))}>{ "Jump to Page::B(B::Two(View::Details))" }</Link<Page>>
             </nav>
         </Section>),
         Page::D { id, target: _target } => html!(
@@ -44,9 +44,9 @@ fn render(page: Page) -> Html {
                     <h3>{ "D" }</h3>
                     <nav>
                         <ul>
-                            <li><Link<Page> target={Page::Index}>{ "Home" }</Link<Page>></li>
-                            <li><Link<D> active="active" predicate={D::is_first} target={D::First}>{ "First" }</Link<D>></li>
-                            <li><Link<D> active="active" predicate={D::is_second} target={D::Second}>{ "Second" }</Link<D>></li>
+                            <li><Link<Page> to={Page::Index}>{ "Home" }</Link<Page>></li>
+                            <li><Link<D> active="active" predicate={D::is_first} to={D::First}>{ "First" }</Link<D>></li>
+                            <li><Link<D> active="active" predicate={D::is_second} to={D::Second}>{ "Second" }</Link<D>></li>
                         </ul>
                     </nav>
                 </Section>
@@ -93,9 +93,9 @@ pub fn view_nav() -> Html {
         <>
             <nav>
                 <ul>
-                    <li><Link<View> active="active" target={View::Overview}>{ "Overview" }</Link<View>></li>
-                    <li><Link<View> active="active" target={View::Details}>{ "Details" }</Link<View>></li>
-                    <li><Link<View> active="active" target={View::Source}>{ "Source" }</Link<View>></li>
+                    <li><Link<View> active="active" to={View::Overview}>{ "Overview" }</Link<View>></li>
+                    <li><Link<View> active="active" to={View::Details}>{ "Details" }</Link<View>></li>
+                    <li><Link<View> active="active" to={View::Source}>{ "Source" }</Link<View>></li>
                 </ul>
             </nav>
         </>
@@ -128,24 +128,24 @@ pub fn app() -> Html {
                         <h2>{"Outside"}</h2>
         
                         <ul>
-                            <li><Link<Page> active="active" target={Page::Index}>{ "Home" }</Link<Page>></li>
-                            <li><Link<Page> active="active" target={Page::A}>{ "A" }</Link<Page>></li>
+                            <li><Link<Page> active="active" to={Page::Index}>{ "Home" }</Link<Page>></li>
+                            <li><Link<Page> active="active" to={Page::A}>{ "A" }</Link<Page>></li>
         
                             <li>
                                 <Scope<Page, B> mapper={Page::mapper_b}>
-                                    <Link<B> active="active" any=true target={B::One}>{ "B" }</Link<B>>
+                                    <Link<B> active="active" any=true to={B::One}>{ "B" }</Link<B>>
                                     <ul>
-                                        <li><Link<Page> active="active" target={Page::B(B::One)}>{ "One" }</Link<Page>></li>
+                                        <li><Link<Page> active="active" to={Page::B(B::One)}>{ "One" }</Link<Page>></li>
                                         <li>
                                             <Scope<B, View> mapper={B::mapper_two}>
-                                                <Link<View> active="active" any=true target={View::Overview}>{ "Two" }</Link<View>>
+                                                <Link<View> active="active" any=true to={View::Overview}>{ "Two" }</Link<View>>
                                                 <ViewNav/>
                                             </Scope<B, View>>
                                         </li>
             
                                         <li>
                                             <Scope<B, View> mapper={B::mapper_three}>
-                                                <Link<View> active="active" predicate={View::any} target={View::Overview}>{ "Three" }</Link<View>>
+                                                <Link<View> active="active" predicate={View::any} to={View::Overview}>{ "Three" }</Link<View>>
                                                 <ViewNav/>
                                             </Scope<B, View>>
                                         </li>
@@ -167,11 +167,11 @@ pub fn app() -> Html {
                     
                             <nav>
                                 <ul> 
-                                    <li><Link<Page> active="active" target={Page::Index}>{ "Home" }</Link<Page>></li>
-                                    <li><Link<Page> active="active" target={Page::A}>{ "A" }</Link<Page>></li>
-                                    <li><Link<Page> active="active" predicate={Page::is_b} target={Page::B(B::One)}>{ "B" }</Link<Page>></li>
-                                    <li><Link<Page> active="active" predicate={Page::is_c} target={Page::C{value: "foo".into(), target: C::Foo{value: "value".to_string()}}}>{ "C (foo)" }</Link<Page>></li>
-                                    <li><Link<Page> active="active" predicate={Page::is_c} target={Page::D {id: 0, target: D::First}}>{ "D (id=0)" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" to={Page::Index}>{ "Home" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" to={Page::A}>{ "A" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" predicate={Page::is_b} to={Page::B(B::One)}>{ "B" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" predicate={Page::is_c} to={Page::C{value: "foo".into(), target: C::Foo{value: "value".to_string()}}}>{ "C (foo)" }</Link<Page>></li>
+                                    <li><Link<Page> active="active" predicate={Page::is_c} to={Page::D {id: 0, target: D::First}}>{ "D (id=0)" }</Link<Page>></li>
                                 </ul>
                             </nav>
                         </div>
@@ -188,7 +188,7 @@ pub fn app() -> Html {
                 <ul>
                     <li>
                         <Link<Page>
-                            target={Page::B(B::Two(View::Details))}
+                            to={Page::B(B::Two(View::Details))}
                             state="Hello World!"
                         >
                             {"Push to B -> Two -> Details with state"}

--- a/src/components/active.rs
+++ b/src/components/active.rs
@@ -10,7 +10,7 @@ where
 {
     /// The target to check for
     #[prop_or_default]
-    pub target: Option<T>,
+    pub route: Option<T>,
 
     /// Its content
     #[prop_or_default]
@@ -52,8 +52,8 @@ where
 
     let mut class = props.class.clone();
 
-    let active = match &props.target {
-        Some(target) => router.is_same(target),
+    let active = match &props.route {
+        Some(route) => router.is_same(route),
         None => router.active().is_some(),
     };
 

--- a/src/components/link.rs
+++ b/src/components/link.rs
@@ -17,8 +17,8 @@ where
     #[prop_or_default]
     pub id: Option<AttrValue>,
 
-    /// The link target.
-    pub target: T,
+    /// The link target route.
+    pub to: T,
 
     /// A state to push, if present
     #[prop_or_default]
@@ -82,7 +82,7 @@ where
                 .clone()
                 .map(|t| predicate.emit(t))
                 .unwrap_or(false),
-            None => router.is_same(&props.target),
+            None => router.is_same(&props.to),
         },
     };
 
@@ -93,7 +93,7 @@ where
 
     let href = match props.element.as_str() {
         "a" if !props.suppress_href => {
-            Some(router.render_target_with(props.target.clone(), props.state.clone()))
+            Some(router.render_target_with(props.to.clone(), props.state.clone()))
         }
         _ => None,
     };
@@ -103,16 +103,16 @@ where
     use_effect_with(
         (
             router,
-            props.target.clone(),
+            props.to.clone(),
             props.state.clone(),
             node_ref.clone(),
         ),
-        |(router, target, state, node_ref)| {
+        |(router, to, state, node_ref)| {
             let mut listener = None;
 
             if let Some(element) = node_ref.cast::<HtmlElement>() {
                 let router = router.clone();
-                let target = target.clone();
+                let to = to.clone();
                 let state = state.clone();
                 listener = Some(EventListener::new_with_options(
                     &element,
@@ -120,7 +120,7 @@ where
                     EventListenerOptions::enable_prevent_default(),
                     move |e| {
                         e.prevent_default();
-                        router.push_with(target.clone(), state.clone());
+                        router.push_with(to.clone(), state.clone());
                     },
                 ));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,9 @@
 //!   html!(
 //!     <>
 //!       <ul>
-//!         <li><Link<AppRoute> target={AppRoute::Index}>{"Index"}</Link<AppRoute>></li>
-//!         <li><Link<AppRoute> target={AppRoute::Foo(Details::Overview)}>{"Foo"}</Link<AppRoute>></li>
-//!         <li><Link<AppRoute> target={AppRoute::Bar{ id: "".into(), details: Details::Overview}}>{"Bar"}</Link<AppRoute>></li>
+//!         <li><Link<AppRoute> to={AppRoute::Index}>{"Index"}</Link<AppRoute>></li>
+//!         <li><Link<AppRoute> to={AppRoute::Foo(Details::Overview)}>{"Foo"}</Link<AppRoute>></li>
+//!         <li><Link<AppRoute> to={AppRoute::Bar{ id: "".into(), details: Details::Overview}}>{"Bar"}</Link<AppRoute>></li>
 //!       </ul>
 //!       <Switch<AppRoute> render={|target|match target {
 //!         AppRoute::Index => html!(<Index/>),


### PR DESCRIPTION
resolves #14

I hope I didn't miss something :)

Not sure what to do with `Active` component. `to` sounds wrong in that context, leaving it as `target` is probably fine despite inconsistency, both have a different purpose. Also, `span` doesn't have a `target` attribute, so no html collision in this case.