### PR TITLE
fix: Increase minimal rust version for transitive dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         toolchain:
           - stable
           # minimum version
-          - "1.70"
+          - "1.73"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`bumpalo`, transitive dependency of `wasm-bindgen` now requires minimal rust version to be 1.73.0

(Alternative is to pin wasm-bindgen to older version, but that doesn't sound like a good idea)